### PR TITLE
Fix nil dir_name crash for paths with no slash separator

### DIFF
--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -191,7 +191,7 @@ function M.show_workspace_selector(window, pane)
 
 		for _, dir in ipairs(zoxide_dirs) do
 			-- Get directory name (last path element)
-			local dir_name = dir:match("([^/]+)$")
+			local dir_name = dir:match("([^/]+)$") or dir
 			local label = wezterm.format({
 				{ Foreground = { Color = colors.zoxide_prefix } },
 				{ Text = labels.zoxide },


### PR DESCRIPTION
## Summary

Fixes #2

When the user's home directory is in the zoxide database, `get_zoxide_directories()` replaces it with `~`. The pattern `dir:match("([^/]+)$")` then returns `nil` (no `/` in `~`), causing a nil concatenation crash at line 199.

## Fix

```lua
-- before
local dir_name = dir:match("([^/]+)$")

-- after
local dir_name = dir:match("([^/]+)$") or dir
```

Falls back to the full path string when no slash component is found, which is safe and meaningful as a label.